### PR TITLE
修复安卓app加载图片失败

### DIFF
--- a/app/luasrc/controller/unblockmusic.lua
+++ b/app/luasrc/controller/unblockmusic.lua
@@ -16,7 +16,7 @@ end
 
 function act_status()
   local e={}
-  e.running=luci.sys.call("ps | grep app.js | grep -v grep >/dev/null")==0
+  e.running=luci.sys.call("ps | grep UnblockNeteaseMusic/app.js | grep -v grep >/dev/null")==0
   luci.http.prepare_content("application/json")
   luci.http.write_json(e)
 end

--- a/app/root/etc/init.d/unblockmusic
+++ b/app/root/etc/init.d/unblockmusic
@@ -19,8 +19,7 @@ add_rule()
 	$ipt_n -A cloud_music -p tcp --dport 443 -j REDIRECT --to-ports $HPORT
 	$ipt_n -I PREROUTING -p tcp -m set --match-set music dst -j cloud_music
 
-  echo 1.81.5.114,1.81.5.115,110.185.122.114,110.185.122.115,14.18.239.11,14.18.239.12,223.202.198.132,223.202.198.134 |grep -Eo '[0-9]+?\.[0-9]+?\.[0-9]+?\.[0-9]+?' | sort | uniq | xargs -i ipset -! add block_music  {}
-	wget http://httpdns.n.netease.com/httpdns/v2/d?domain=p2.music.126.net,interface.music.163.com,interface3.music.163.com,clientlog.music.163.com,apm.music.163.com,apm3.music.163.com,p1.music.126.net,clientlog3.music.163.com -O- | grep -Eo '[0-9]+?\.[0-9]+?\.[0-9]+?\.[0-9]+?' | sort | uniq | xargs -i ipset -! add music  {}
+	wget http://httpdns.n.netease.com/httpdns/v2/d?domain=music.163.com,interface.music.163.com,interface3.music.163.com,apm.music.163.com,apm3.music.163.com,clientlog.music.163.com,clientlog3.music.163.com -O- | grep -Eo '[0-9]+?\.[0-9]+?\.[0-9]+?\.[0-9]+?' | sort | uniq | xargs -i ipset -! add music  {}
 }
 
 del_rule(){
@@ -58,9 +57,9 @@ start()
 	[ $enable -eq "0" ] && exit 0
 	
 	if [ $TYPE = "default" ]; then
-			node /usr/share/UnblockNeteaseMusic/app.js -p $PORT:$HPORT >/tmp/unblockmusic.log 2>&1 &
+		node /usr/share/UnblockNeteaseMusic/app.js -p $PORT:$HPORT >/tmp/unblockmusic.log 2>&1 &
 	else
-			node /usr/share/UnblockNeteaseMusic/app.js -p $PORT:$HPORT -o $TYPE >/tmp/unblockmusic.log 2>&1 &
+		node /usr/share/UnblockNeteaseMusic/app.js -p $PORT:$HPORT -o $TYPE >/tmp/unblockmusic.log 2>&1 &
 	fi
 	
 	set_firewall

--- a/app/root/etc/init.d/unblockmusic
+++ b/app/root/etc/init.d/unblockmusic
@@ -15,8 +15,8 @@ add_rule()
 {
   ipset -! -N music hash:ip
 	$ipt_n -N cloud_music
-	$ipt_n -A cloud_music -p tcp --dport 80 -j REDIRECT --to-ports 5200
-	$ipt_n -A cloud_music -p tcp --dport 443 -j REDIRECT --to-ports 5201
+	$ipt_n -A cloud_music -p tcp --dport 80 -j REDIRECT --to-ports $PORT
+	$ipt_n -A cloud_music -p tcp --dport 443 -j REDIRECT --to-ports $HPORT
 	$ipt_n -I PREROUTING -p tcp -m set --match-set music dst -j cloud_music
 
   echo 1.81.5.114,1.81.5.115,110.185.122.114,110.185.122.115,14.18.239.11,14.18.239.12,223.202.198.132,223.202.198.134 |grep -Eo '[0-9]+?\.[0-9]+?\.[0-9]+?\.[0-9]+?' | sort | uniq | xargs -i ipset -! add block_music  {}

--- a/app/root/etc/init.d/unblockmusic
+++ b/app/root/etc/init.d/unblockmusic
@@ -18,8 +18,9 @@ add_rule()
 	$ipt_n -A cloud_music -p tcp --dport 80 -j REDIRECT --to-ports 5200
 	$ipt_n -A cloud_music -p tcp --dport 443 -j REDIRECT --to-ports 5201
 	$ipt_n -I PREROUTING -p tcp -m set --match-set music dst -j cloud_music
-	wget http://httpdns.n.netease.com/httpdns/v2/d?domain=p2.music.126.net,interface.music.163.com,interface3.music.163.com,clientlog.music.163.com,apm.music.163.com,apm3.music.163.com,p1.music.126.net,clientlog3.music.163.com -O- | grep -Eo '[0-9]+?\.[0-9]+?\.[0-9]+?\.[0-9]+?' | sort | uniq | awk '{print "ipset add music "$1}' > /tmp/musicip.sh
-	sh /tmp/musicip.sh
+
+  echo 1.81.5.114,1.81.5.115,110.185.122.114,110.185.122.115,14.18.239.11,14.18.239.12,223.202.198.132,223.202.198.134 |grep -Eo '[0-9]+?\.[0-9]+?\.[0-9]+?\.[0-9]+?' | sort | uniq | xargs -i ipset -! add block_music  {}
+	wget http://httpdns.n.netease.com/httpdns/v2/d?domain=p2.music.126.net,interface.music.163.com,interface3.music.163.com,clientlog.music.163.com,apm.music.163.com,apm3.music.163.com,p1.music.126.net,clientlog3.music.163.com -O- | grep -Eo '[0-9]+?\.[0-9]+?\.[0-9]+?\.[0-9]+?' | sort | uniq | xargs -i ipset -! add music  {}
 }
 
 del_rule(){
@@ -37,6 +38,9 @@ set_firewall(){
 	echo "dhcp-option=252,http://$ROUTE_IP:$PORT/proxy.pac" > /tmp/dnsmasq.d/dnsmasq-163.conf
 	echo "ipset=/music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
 	echo "ipset=/interface.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
+	echo "ipset=/interface3.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
+	echo "ipset=/apm.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
+	echo "ipset=/apm3.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
 	/etc/init.d/dnsmasq restart >/dev/null 2>&1
 	
 	add_rule

--- a/app/root/etc/init.d/unblockmusic
+++ b/app/root/etc/init.d/unblockmusic
@@ -70,7 +70,7 @@ start()
 
 stop()
 {
-	kill -9 $(ps | grep app.js | grep -v grep | awk '{print $1}') >/dev/null 2>&1
+	kill -9 $(ps | grep UnblockNeteaseMusic/app.js | grep -v grep | awk '{print $1}') >/dev/null 2>&1
 	kill -9 $(ps | grep logcheck.sh | grep -v grep | awk '{print $1}') >/dev/null 2>&1
 	rm -f /tmp/unblockmusic.log
 	rm -f /tmp/music.log


### PR DESCRIPTION
1. 修改httpdns解析的域名列表。移除了cdn域名，补上`music.163.com`
2. 修改写到dnsmasq配置的域名列表，即使域名动态解析变更了，也不需要手动重启脚本
3. 小部分代码优化


Closes #62 