### PR TITLE
修复多个问题

### DIFF
--- a/UnblockNeteaseMusic/Makefile
+++ b/UnblockNeteaseMusic/Makefile
@@ -11,14 +11,14 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=UnblockNeteaseMusic
-PKG_VERSION:=0.21.0
+PKG_VERSION:=0.22.3
 PKG_RELEASE:=1
 
 PKG_LICENSE:=MIT
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/nondanee/UnblockNeteaseMusic.git
-PKG_SOURCE_VERSION:=00c857d5cb9ca7a009cded7d52ebc21c875875f0
+PKG_SOURCE_VERSION:=b1b34db941553e600820b35791e7926ef462686f
 
 PKG_SOURCE_SUBDIR:=$(PKG_NAME)
 PKG_SOURCE:=$(PKG_SOURCE_SUBDIR)-$(PKG_VERSION).tar.gz
@@ -43,8 +43,9 @@ endef
 
 define Build/Prepare
 	tar -xzvf $(DL_DIR)/$(PKG_SOURCE) -C $(PKG_BUILD_DIR)
-	echo -e $(PKG_VERSION) > $(PKG_BUILD_DIR)/UnblockNeteaseMusic/core_ver
-	echo -e $(PKG_SOURCE_VERSION) > $(PKG_BUILD_DIR)/UnblockNeteaseMusic/local_ver
+	mkdir -p $(PKG_BUILD_DIR)/$(PKG_NAME)
+	echo -e $(PKG_VERSION) > $(PKG_BUILD_DIR)/$(PKG_NAME)/core_ver
+	echo -e $(PKG_SOURCE_VERSION) > $(PKG_BUILD_DIR)/$(PKG_NAME)/local_ver
 endef
 
 define Build/Configure

--- a/app/luasrc/model/cbi/unblockmusic.lua
+++ b/app/luasrc/model/cbi/unblockmusic.lua
@@ -24,7 +24,6 @@ speedtype:value("migu", translate("咕咪音乐"))
 speedtype:value("joox", translate("JOOX音乐"))
 
 endpoint = s:option(Value, "endpoint", translate("转发HTTPS音源地址"))
-endpoint.default = "https://music.163.com"
 endpoint.rmempty = true
 endpoint.description = translate("默认为 https://music.163.com")
 

--- a/app/luasrc/model/cbi/unblockmusiclog.lua
+++ b/app/luasrc/model/cbi/unblockmusiclog.lua
@@ -1,6 +1,5 @@
 local fs = require "nixio.fs"
 local conffile = "/tmp/unblockmusic.log"
-local conffile = "/tmp/music.log"
 
 f = SimpleForm("logview")
 
@@ -8,7 +7,6 @@ t = f:field(TextValue, "conf")
 t.rmempty = true
 t.rows = 20
 function t.cfgvalue()
-	luci.sys.exec("cat /tmp/unblockmusic.log | grep http > /tmp/music.log")
 	return fs.readfile(conffile) or ""
 end
 t.readonly="readonly"

--- a/app/root/etc/config/unblockmusic
+++ b/app/root/etc/config/unblockmusic
@@ -1,7 +1,6 @@
 
 config unblockmusic
 	option enabled '0'
-        option musicapptype 'default'
-	option enable_ipset '1'
+	option musicapptype 'default'
 	option endpoint 'https://music.163.com'
 	option autoupdate '1'

--- a/app/root/etc/init.d/unblockmusic
+++ b/app/root/etc/init.d/unblockmusic
@@ -25,8 +25,8 @@ add_rule()
 	$ipt_n -A cloud_music -d 192.168.0.0/16 -j RETURN
 	$ipt_n -A cloud_music -d 224.0.0.0/4 -j RETURN
 	$ipt_n -A cloud_music -d 240.0.0.0/4 -j RETURN
-	$ipt_n -A cloud_music -p tcp --dport 80 -j REDIRECT --to-ports 5201
-	$ipt_n -A cloud_music -p tcp --dport 443 -j REDIRECT --to-ports 5202
+	$ipt_n -A cloud_music -p tcp --dport 80 -j REDIRECT --to-ports 5200
+	$ipt_n -A cloud_music -p tcp --dport 443 -j REDIRECT --to-ports 5201
 	$ipt_n -I PREROUTING -p tcp -m set --match-set music dst -j cloud_music
 	wget http://httpdns.n.netease.com/httpdns/v2/d?domain=music.163.com,interface.music.163.com,interface3.music.163.com,apm.music.163.com,apm3.music.163.com,clientlog.music.163.com,clientlog3.music.163.com -O- | grep -Eo '[0-9]+?\.[0-9]+?\.[0-9]+?\.[0-9]+?' | sort | uniq | awk '{print "ipset -! add music "$1}' | sh
 
@@ -48,7 +48,7 @@ del_rule(){
 set_firewall(){
   rm -f /tmp/dnsmasq.d/dnsmasq-163.conf
   mkdir -p /tmp/dnsmasq.d
-  echo "dhcp-option=252,http://$ROUTE_IP:5201/proxy.pac" > /tmp/dnsmasq.d/dnsmasq-163.conf
+  echo "dhcp-option=252,http://$ROUTE_IP:5200/proxy.pac" > /tmp/dnsmasq.d/dnsmasq-163.conf
 	echo "ipset=/music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
 	echo "ipset=/interface.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
 	echo "ipset=/interface3.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
@@ -95,9 +95,9 @@ start()
 	echo "$(date -R) # Start UnblockNeteaseMusic" >/tmp/unblockmusic.log
 
 	if [ $TYPE = "default" ]; then
-		node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5201:5202 >>/tmp/unblockmusic.log 2>&1 &
+		node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5200:5201 >>/tmp/unblockmusic.log 2>&1 &
 	else
-		node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5201:5202 -o $TYPE >>/tmp/unblockmusic.log 2>&1 &
+		node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5200:5201 -o $TYPE >>/tmp/unblockmusic.log 2>&1 &
 	fi
 	
 	set_firewall

--- a/app/root/etc/init.d/unblockmusic
+++ b/app/root/etc/init.d/unblockmusic
@@ -28,6 +28,7 @@ add_rule()
 	$ipt_n -A cloud_music -p tcp --dport 80 -j REDIRECT --to-ports 5201
 	$ipt_n -A cloud_music -p tcp --dport 443 -j REDIRECT --to-ports 5202
 	$ipt_n -I PREROUTING -p tcp -m set --match-set music dst -j cloud_music
+	wget http://httpdns.n.netease.com/httpdns/v2/d?domain=music.163.com,interface.music.163.com,interface3.music.163.com,apm.music.163.com,apm3.music.163.com,clientlog.music.163.com,clientlog3.music.163.com -O- | grep -Eo '[0-9]+?\.[0-9]+?\.[0-9]+?\.[0-9]+?' | sort | uniq | awk '{print "ipset -! add music "$1}' | sh
 
 	kprule=$(iptables -t nat -L KOOLPROXY | grep "UnblockMusic" | sed 's/\/.*//')
 	[ ! -n "$kprule" ] && $ipt_n -I KOOLPROXY -m set --match-set music dst -j RETURN -m comment --comment "for UnblockMusic"

--- a/app/root/etc/init.d/unblockmusic
+++ b/app/root/etc/init.d/unblockmusic
@@ -41,6 +41,7 @@ del_rule(){
 	
 	rm -f /tmp/dnsmasq.d/dnsmasq-163.conf
 	/etc/init.d/dnsmasq reload >/dev/null 2>&1
+	ipset destroy music
 }
 
 set_firewall(){

--- a/app/root/etc/init.d/unblockmusic
+++ b/app/root/etc/init.d/unblockmusic
@@ -36,7 +36,7 @@ del_rule(){
 	$ipt_n -X cloud_music  2>/dev/null
 	
 	rm -f /tmp/dnsmasq.d/dnsmasq-163.conf
-	/etc/init.d/dnsmasq restart >/dev/null 2>&1
+	/etc/init.d/dnsmasq reload >/dev/null 2>&1
 }
 
 set_firewall(){
@@ -48,7 +48,7 @@ set_firewall(){
 	echo "ipset=/interface3.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
 	echo "ipset=/apm.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
 	echo "ipset=/apm3.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
-	/etc/init.d/dnsmasq restart >/dev/null 2>&1
+	/etc/init.d/dnsmasq reload >/dev/null 2>&1
 	
 	add_rule
 	

--- a/app/root/etc/init.d/unblockmusic
+++ b/app/root/etc/init.d/unblockmusic
@@ -25,12 +25,13 @@ add_rule()
 	$ipt_n -A cloud_music -d 192.168.0.0/16 -j RETURN
 	$ipt_n -A cloud_music -d 224.0.0.0/4 -j RETURN
 	$ipt_n -A cloud_music -d 240.0.0.0/4 -j RETURN
-	$ipt_n -A cloud_music -p tcp -j REDIRECT --to-ports 5202
-	$ipt_n -I PREROUTING -p tcp --dport 80 -m set --match-set music dst -j cloud_music
+	$ipt_n -A cloud_music -p tcp --dport 80 -j REDIRECT --to-ports 5201
+	$ipt_n -A cloud_music -p tcp --dport 443 -j REDIRECT --to-ports 5202
+	$ipt_n -I PREROUTING -p tcp -m set --match-set music dst -j cloud_music
 }
 
 del_rule(){
-	$ipt_n -D PREROUTING -p tcp --dport 80 -m set --match-set music dst -j cloud_music 2>/dev/null
+	$ipt_n -D PREROUTING -p tcp -m set --match-set music dst -j cloud_music 2>/dev/null
 	$ipt_n -F cloud_music  2>/dev/null
 	$ipt_n -X cloud_music  2>/dev/null
 	
@@ -41,9 +42,12 @@ del_rule(){
 set_firewall(){
   rm -f /tmp/dnsmasq.d/dnsmasq-163.conf
   mkdir -p /tmp/dnsmasq.d
-  echo "dhcp-option=252,http://$ROUTE_IP:5200/proxy.pac" > /tmp/dnsmasq.d/dnsmasq-163.conf
+  echo "dhcp-option=252,http://$ROUTE_IP:5201/proxy.pac" > /tmp/dnsmasq.d/dnsmasq-163.conf
 	echo "ipset=/music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
 	echo "ipset=/interface.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
+	echo "ipset=/interface3.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
+	echo "ipset=/apm.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
+	echo "ipset=/apm3.music.163.com/music" >> /tmp/dnsmasq.d/dnsmasq-163.conf
 	/etc/init.d/dnsmasq restart >/dev/null 2>&1
 	
 	add_rule
@@ -82,11 +86,9 @@ start()
 	fi
 	
 	if [ $TYPE = "default" ]; then
-			node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5200:5201 >/tmp/unblockmusic.log 2>&1 &
-			node /usr/share/UnblockNeteaseMusic/app.js -p 5202 >>/tmp/unblockmusic.log 2>&1 &
+			node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5201:5202 >/tmp/unblockmusic.log 2>&1 &
 	else
-			node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5200:5201 -o $TYPE >/tmp/unblockmusic.log 2>&1 &
-			node /usr/share/UnblockNeteaseMusic/app.js -p 5202 -o $TYPE >>/tmp/unblockmusic.log 2>&1 &
+			node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5201:5202 -o $TYPE >/tmp/unblockmusic.log 2>&1 &
 	fi
 	
 	set_firewall
@@ -99,7 +101,6 @@ stop()
 {	kill -9 $(busybox ps -w | grep UnblockNeteaseMusic/app.js  | grep -v grep | awk '{print $1}') >/dev/null 2>&1
 	kill -9 $(busybox ps -w | grep logcheck.sh | grep -v grep | awk '{print $1}') >/dev/null 2>&1
 	rm -f /tmp/unblockmusic.log
-	rm -f /tmp/music.log
 	
 	del_rule
 	del_cron

--- a/app/root/etc/init.d/unblockmusic
+++ b/app/root/etc/init.d/unblockmusic
@@ -1,6 +1,6 @@
 #!/bin/sh /etc/rc.common
 
-START=80
+START=99
 STOP=10
 
 enable=$(uci get unblockmusic.@unblockmusic[0].enabled)

--- a/app/root/etc/init.d/unblockmusic
+++ b/app/root/etc/init.d/unblockmusic
@@ -91,10 +91,13 @@ start()
 		endponintset="-e ${ENDPOINT}"
 	fi
 	
+	rm -f /tmp/unblockmusic.log
+	echo "$(date -R) # Start UnblockNeteaseMusic" >/tmp/unblockmusic.log
+
 	if [ $TYPE = "default" ]; then
-			node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5201:5202 >/tmp/unblockmusic.log 2>&1 &
+		node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5201:5202 >>/tmp/unblockmusic.log 2>&1 &
 	else
-			node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5201:5202 -o $TYPE >/tmp/unblockmusic.log 2>&1 &
+		node /usr/share/UnblockNeteaseMusic/app.js $endponintset -p 5201:5202 -o $TYPE >>/tmp/unblockmusic.log 2>&1 &
 	fi
 	
 	set_firewall

--- a/app/root/etc/init.d/unblockmusic
+++ b/app/root/etc/init.d/unblockmusic
@@ -28,10 +28,14 @@ add_rule()
 	$ipt_n -A cloud_music -p tcp --dport 80 -j REDIRECT --to-ports 5201
 	$ipt_n -A cloud_music -p tcp --dport 443 -j REDIRECT --to-ports 5202
 	$ipt_n -I PREROUTING -p tcp -m set --match-set music dst -j cloud_music
+
+	kprule=$(iptables -t nat -L KOOLPROXY | grep "UnblockMusic" | sed 's/\/.*//')
+	[ ! -n "$kprule" ] && $ipt_n -I KOOLPROXY -m set --match-set music dst -j RETURN -m comment --comment "for UnblockMusic"
 }
 
 del_rule(){
 	$ipt_n -D PREROUTING -p tcp -m set --match-set music dst -j cloud_music 2>/dev/null
+	$ipt_n -D KOOLPROXY -m set --match-set music dst -j RETURN -m comment --comment "for UnblockMusic" 2>/dev/null
 	$ipt_n -F cloud_music  2>/dev/null
 	$ipt_n -X cloud_music  2>/dev/null
 	

--- a/app/root/usr/share/UnblockNeteaseMusic/logcheck.sh
+++ b/app/root/usr/share/UnblockNeteaseMusic/logcheck.sh
@@ -5,11 +5,6 @@ log_file="/tmp/unblockmusic.log"
 
 while true
 do
-	sleep 10s
-	icount=`busybox ps -w | grep app.js |grep -v grep| wc -l`
-	if [ $icount -ne 2 ] ;then 
-	/etc/init.d/unblockmusic restart 
-	fi
 	(( log_size = "$(ls -l "${log_file}" | awk -F ' ' '{print $5}')" / "1024" ))
 	(( "${log_size}" >= "${log_max_size}" )) && echo "" > /tmp/unblockmusic.log
 	sleep 10m

--- a/app/root/usr/share/UnblockNeteaseMusic/update_core.sh
+++ b/app/root/usr/share/UnblockNeteaseMusic/update_core.sh
@@ -37,7 +37,9 @@ function update_core(){
 
 	wget-ssl --no-check-certificate -t 1 -T 10 -O  /tmp/unblockneteasemusic/core/core.tar.gz "https://github.com/nondanee/UnblockNeteaseMusic/archive/master.tar.gz"  >/dev/null 2>&1
 	tar -zxf "/tmp/unblockneteasemusic/core/core.tar.gz" -C "/tmp/unblockneteasemusic/core/" >/dev/null 2>&1
-	rm -f /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-master/ca.crt /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-master/server.crt /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-master/server.key
+	if [ -e "/usr/share/UnblockNeteaseMusic/ca.crt" ] && [ -e "/usr/share/UnblockNeteaseMusic/server.crt" ] && [ -e "/usr/share/UnblockNeteaseMusic/server.key" ] ; then
+		rm -f /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-master/ca.crt /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-master/server.crt /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-master/server.key
+	fi
 	cp -a /tmp/unblockneteasemusic/core/UnblockNeteaseMusic-master/* "/usr/share/UnblockNeteaseMusic/"
 	rm -rf "/tmp/unblockneteasemusic" >/dev/null 2>&1
 


### PR DESCRIPTION
## 修复问题
- 无法将`转发HTTPS音源地址`设置为空
- 日志页面无法显示完整日志
- 修复防火墙策略
    之前的防火墙策略只能使非ssl连接生效，导致部分平台的客户端使用出现问题
- 修复启动时获取域名列表存入ipset
    之前被人移除了，服务不会立马生效，只有触发网卡连接事件时才更新
- 更新功能中，如果本地不存在证书，则使用默认证书
    适用于本地无证书/本地没有**UnblockNeteaseMusic**包的情况

## 修改/调整
- 脚本启动顺序重新改为99
    原顺序为80，作为一个第三方服务不需要那么靠前的启动顺序，且如ss、koolproxy之类的服务启动顺序为99，他们启动后会修改防火墙策略，有可能导致unblockmusic的防火墙策略顺序靠后导致无法执行到（比如koolproxy）
- 不重启`dnsmasq`服务，改为`重载`，避免影响dns解析

## 优化
- 移除多余无用的配置项
- 增加对`KOOLPROXY`的防火墙策略
   如果`openwrt`上启用了`KOOLPROXY`，且防火墙策略优先于unblockmusic的策略，会导致访问不走unblockmusic，此项对此进行了处理。对于未启用`KOOLPROXY`的无影响，**可忽略**
- 简化启动**UnblockNeteaseMusic**的进程数量，只需要一个就行了，干嘛启动两个占用资源
    这个有点不理解为什么要拆分成两个进程，一个进程就解决的事情。如果是拆分成两个有什么特殊用途请指教
